### PR TITLE
Fix building docs on readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 version: 2
 sphinx:
-  configuration: docs/conf.py
+  configuration: docs/source/conf.py
 formats: all
 python:
   install:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -53,9 +53,6 @@ extensions = [
     'sphinx.ext.intersphinx'
 ]
 
-source_suffix = '.rst'
-master_doc = 'index'
-
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.


### PR DESCRIPTION
Changes made:

* Put correct path to the sphinx configuration in the `.readthedocs.yml`