### PR TITLE
Add example of displaying images in the documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ A Python implementaiton of `Metrics Reloaded <https://openreview.net/forum?id=24
     :scale: 10%
     :align: center
 
-    Metrics Reloaded fosters the convergence of validation methodology across modalities, ap- plication domains and classification scales
+    Metrics Reloaded fosters the convergence of validation methodology across modalities, application domains and classification scales
 
 Installation
 ============

--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,12 @@ Metrics Reloaded
 
 A Python implementaiton of `Metrics Reloaded <https://openreview.net/forum?id=24kBqy8rcB_>`__ - A new recommendation framework for biomedical image analysis validation.
 
+.. figure:: /images/classification_scales_and_domains.png
+    :scale: 10%
+    :align: center
+
+    Metrics Reloaded fosters the convergence of validation methodology across modalities, ap- plication domains and classification scales
+
 Installation
 ============
 Using git

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -63,6 +63,7 @@ autodoc_docstring_signature = True
 autoclass_content = 'both'
 autodoc_member_order = 'bysource'
 
+html_static_path = ["_static"]
 templates_path = ['_templates']
 extlinks = {
     'issue': ('https://github.com/csudre/MetricsReloaded/issues/%s', '#'),


### PR DESCRIPTION
Changes made:

* Added a folder to store images: `docs/source/images`
* Added an image to the main README. It references an image stored in `docs/source/images`. It does this using an absolute path where the root is `docs/source`

Note, I have used the `figure` directive, which allows you to add a caption. If you do not want to add a caption use the `image` directive instead.
