### PR TITLE
Specify files to include when checking test coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,7 +8,8 @@ source = MetricsReloaded
 include = MetricsReloaded
 parallel = true
 omit =
-    *tests*
+    test/
+    *test*
     *__init__.py
     MetricsReloaded/_version.py
 

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,34 @@
+[paths]
+source =
+   .
+
+[run]
+branch = true
+source = MetricsReloaded
+include = MetricsReloaded
+parallel = true
+omit =
+    *tests*
+    *__init__.py
+    MetricsReloaded/_version.py
+
+[report]
+show_missing = true
+precision = 2
+# Regexes for lines to exclude from consideration
+exclude_lines =
+
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:


### PR DESCRIPTION
Changes made:

* Added a `.coverage` config file to specify which files to include / exclude when checking test coverage